### PR TITLE
pathname error on ruby 1.9

### DIFF
--- a/bin/pow
+++ b/bin/pow
@@ -1,6 +1,5 @@
 #!/usr/bin/ruby
-require 'pathname'
-bin  = Pathname.new(__FILE__).realpath
-root = bin.dirname.parent
-ENV['POW_BIN'] = bin.to_s
-exec root.join("bin/node").to_s, root.join("lib/command.js").to_s, *ARGV
+path = File.expand_path "../../", __FILE__
+ENV['POW_BIN'] = bin = "#{path}/bin/pow"
+root = path
+exec "#{path}/bin/node", "#{path}/lib/command.js", *ARGV


### PR DESCRIPTION
My ruby version(s):
    $ ruby -v
    ruby 1.9.2p188 (2011-03-28 revision 31204) [x86_64-darwin10.7.0]
    $ rvm system
    $ ruby -v
    $ ruby 1.9.2p180 (2011-02-18 revision 30909) [x86_64-darwin10.7.0]

I was getting this error when trying to install pow from remote:

```
> curl get.pow.cx | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2722  100  2722    0     0   4827      0 --:--:-- --:--:-- --:--:--  8586
*** Installing Pow 0.2.2...
*** Installing local configuration files...
/Users/makevoid/Library/Application Support/Pow/Current/bin/pow:3:in `[]=': can't convert Pathname into String (TypeError)
    from /Users/makevoid/Library/Application Support/Pow/Current/bin/pow:3:in `<main>'
```

Then I downloaded the source and changed install.sh to overwrite the copied /bin/pow with the one you have in the pull request. 

Thanks for pow, it's great!
