### PR TITLE
umask fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,9 @@
 
       echo "*** Installing Pow $VERSION..."
 
+# Some people use umask 002 which makes launchctl script unstartable
+
+      umask 022
 
 # Create the Pow directory structure if it doesn't already exist.
 


### PR DESCRIPTION
pow installation did not work for me "out of the box".
turns out, permissions for ~/Library/LaunchAgents/cx.pow.powd.plist were wrong because of my umask 002 in .zshprofile. launchctl won't start group writable .plist

I've added umask in install.sh, it was just easier for me than make changes in js source.
