### PR TITLE
Broken tests: Added `env` argument to all Rackup test fixtures

### DIFF
--- a/test/fixtures/apps/env/config.ru
+++ b/test/fixtures/apps/env/config.ru
@@ -1,6 +1,6 @@
 require "json"
 
-run lambda {
+run lambda { |env|
   body = ENV.keys.grep(/^POW/).inject({}) { |e, k| e.merge(k => ENV[k]) }.to_json
   [200, {'Content-Type' => 'text/plain', 'Content-Length' => body.length.to_s}, [body]]
 }

--- a/test/fixtures/apps/error/ok.ru
+++ b/test/fixtures/apps/error/ok.ru
@@ -1,1 +1,1 @@
-run lambda { [200, {'Content-Type' => 'text/plain'}, ['OK']] }
+run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }

--- a/test/fixtures/apps/pid/config.ru
+++ b/test/fixtures/apps/pid/config.ru
@@ -1,4 +1,4 @@
-run lambda {
+run lambda { |env|
   body = Process.pid.to_s
   [200, {'Content-Type' => 'text/plain', 'Content-Length' => body.length.to_s}, [body]]
 }

--- a/test/fixtures/apps/rc-error/config.ru
+++ b/test/fixtures/apps/rc-error/config.ru
@@ -1,3 +1,3 @@
-run lambda {
+run lambda { |env|
   [200, {'Content-Type' => 'text/plain', 'Content-Length' => '5'}, ['Hello']]
 }


### PR DESCRIPTION
The test suite wouldn't pass, and the individual fixtures wouldn't run in pow without this required rack argument.

Without these fixes, for me, `cake test` failed with the following in `test_http_server`:

```
SyntaxError: Unexpected token ILLEGAL
    at Object.parse (native)
    at /Users/rmcgeary/work/oss/rmm5t/pow/test/test_http_server.coffee:46:43
    at IncomingMessage.<anonymous> (/Users/rmcgeary/work/oss/rmm5t/pow/test/lib/test_helper.coffee:86:18)
    ...
```

Also, when trying to run the env.dev fixture application directly in pow, the following error occured:

```
ArgumentError: wrong number of arguments (1 for 0)
    /Users/rmcgeary/work/oss/rmm5t/pow/test/fixtures/apps/env/config.ru:4:in `block (2 levels) in <main>'
    /Users/rmcgeary/Library/Application Support/Pow/Versions/0.2.2/node_modules/nack/lib/nack/server.rb:146:in `call'
    /Users/rmcgeary/Library/Application Support/Pow/Versions/0.2.2/node_modules/nack/lib/nack/server.rb:146:in `handle'
    ...
```
