### PR TITLE
Fix Issue #87 - redirect only traffic destined to 127.0.0.1

### DIFF
--- a/src/cx.pow.firewall.plist.eco
+++ b/src/cx.pow.firewall.plist.eco
@@ -8,7 +8,7 @@
 	<array>
 		<string>sh</string>
 		<string>-c</string>
-		<string>ipfw add fwd 127.0.0.1,<%= @httpPort %> tcp from any to me dst-port <%= @dstPort %> in &amp;&amp; sysctl -w net.inet.ip.forwarding=1</string>
+		<string>ipfw add fwd 127.0.0.1,<%= @httpPort %> tcp from any to 127.0.0.1 dst-port <%= @dstPort %> in &amp;&amp; sysctl -w net.inet.ip.forwarding=1</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>


### PR DESCRIPTION
Only redirect traffic that was destined to 127.0.0.1 (where the POW is running).
This allows to run Apache on second IP 127.0.0.2 and have /etc/hosts file serve the hostname.
