### PR TITLE
changed install bash script to use the current ruby instead of /usr/bin/ruby)

### DIFF
--- a/bin/pow
+++ b/bin/pow
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 require 'pathname'
 bin  = Pathname.new(__FILE__).realpath
 root = bin.dirname.parent


### PR DESCRIPTION
The current version of the install script uses `#! /usr/bin/ruby`, but not all computers have their ruby version at that location. I've changed it to `#! /usr/bin/env ruby`. This is the result of an issue I ran into with oAuth and the openSSL library not being loaded. After adding anything with a flag to `RUBYOPT` (like `export RUBYOPT='-r openssl'`, you can no longer install POW (fails with illegal switch `-o`). Changing the bash path resolved this issue for me.
