### PR TITLE
Fix bad content body (EOFError) when uploading a file.

### DIFF
--- a/lib/rack_application.js
+++ b/lib/rack_application.js
@@ -179,6 +179,7 @@
     };
     RackApplication.prototype.handle = function(req, res, next, callback) {
       var resume;
+      req.pause();
       resume = pause(req);
       return this.ready(__bind(function(err) {
         if (err) {
@@ -197,6 +198,7 @@
                 return next(err);
               }, this));
             } finally {
+              req.resume();
               resume();
               if (typeof callback === "function") {
                 callback();

--- a/src/rack_application.coffee
+++ b/src/rack_application.coffee
@@ -201,6 +201,7 @@ module.exports = class RackApplication
   # request along to the Nack pool. If the Nack worker raises an
   # exception handling the request, reset the application.
   handle: (req, res, next, callback) ->
+    req.pause()
     resume = pause req
     @ready (err) =>
       return next err if err
@@ -213,6 +214,7 @@ module.exports = class RackApplication
               @quit() if err
               next err
           finally
+            req.resume()
             resume()
             callback?()
 


### PR DESCRIPTION
Should fix issue #125.

The problem lies in duplicated data chunks in the resulting body which gets passed to Nack. The request body becomes larger than expected and thus corrupted.

The bug is not Rails-related, let alone Paperclip-related.

The bug can be observed mainly for larger files and depends on async IO events and that's why it is not 100% predictable. The duplication occurs due to redundant re-emitting of the 'data' event by the custom-written `util.pause(stream)` function. The culprit of it is in `RackApplication#handle`.

The custom `util.pause()`/`resume()` are needed at least for the tests to pass. When removed from `RackApplication#handle`, Pow seems to work correctly and does not manifest the bug in question, but the tests within `test_rack_application.coffee` hang and just timeout. I suppose this is due to the `'end'` event not being paused by `Stream#pause()`.

This little change is the result of one of the most epic debugging sessions I've ever pulled out :) This callback-infested code is really not very easy to get along with and debug, but I like Pow very much and I got fed up with the +1's in the issue, so... I spent the night hunting it down.

Cheers!
