### PR TITLE
Stricter http-proxy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "async": "0.1.8"
   , "coffee-script": ">= 1.1.0"
   , "connect": ">= 1.0.3"
-  , "http-proxy": ">= 0.5.8"
+  , "http-proxy": "~> 0.5.8"
   , "log": ">= 1.1.1"
   , "nack": ">= 0.12.2"
   , "ndns": ">= 0.1.2"


### PR DESCRIPTION
I was experiencing issues getting the tests to pass for the proxy-to-port patch that's in master. After a bit of investigation it seems that the newer versions of node-http-proxy (>= 0.6) have changed their API.

Pow uses the [0.5.x API](https://github.com/37signals/pow/blob/master/src/http_server.coffee#L182) for HttpProxy, which is not compatible with the [newer API](https://github.com/nodejitsu/node-http-proxy/blob/v0.7.0/lib/node-http-proxy/http-proxy.js#L50-L53).

This patch takes the "easy" option and locks the dependency down to the 0.5.x API. It may, however, be preferable to upgrade pow to use the newer API.
