### PR TITLE
Configuration documentation update

### DIFF
--- a/src/configuration.coffee
+++ b/src/configuration.coffee
@@ -84,7 +84,10 @@ module.exports = class Configuration
     @workers    = options.workers    ? env.POW_WORKERS     ? 2
 
     # `domains`: the top-level domains for which Pow will respond to
-    # DNS `A` queries with `127.0.0.1`. Defaults to `dev`.
+    # DNS `A` queries with `127.0.0.1`. Defaults to `dev`. If you  
+    # configure this in your `~/.powconfig` you will need to re-run 
+    # `sudo pow --install-system` to make `/etc/resolver` aware of
+    # the new TLD's.
     @domains    = options.domains    ? env.POW_DOMAINS     ? env.POW_DOMAIN ? "dev"
 
     # `extDomains`: additional top-level domains for which Pow will


### PR DESCRIPTION
I got a bit stuck with this today and thought that it might be nice to have a little more info on how to get `/etc/resolver` updated with new TLD's if you set `export POW_DOMAIN=foo` in your `~/powconfig`.

Cheers,
Chris
