### PR TITLE
Heroku support for default config.ru in "Rackup file missing" page

### DIFF
--- a/lib/templates/http_server/rackup_file_missing.html.js
+++ b/lib/templates/http_server/rackup_file_missing.html.js
@@ -25,7 +25,7 @@ module.exports = function(__obj) {
         title: "Rackup file missing"
       }, function() {
         return _capture(function() {
-          return _print(_safe('\n  <h1 class="err">Rackup file missing</h1>\n  <h2>Your Rails app needs a <code>config.ru</code> file.</h2>\n  <section>\n    <p>If your app is using Rails 2.3, create a <code>config.ru</code> file in the application root containing the following:</p>\n    <pre class="breakout">require File.dirname(__FILE__) + \'/config/environment\'\nrun ActionController::Dispatcher.new</pre>\n    <p>If you&rsquo;re using a version of Rails older than 2.3, you&rsquo;ll need to upgrade first.</p>\n  </section>\n'));
+          return _print(_safe('\n  <h1 class="err">Rackup file missing</h1>\n  <h2>Your Rails app needs a <code>config.ru</code> file.</h2>\n  <section>\n    <p>If your app is using Rails 2.3, create a <code>config.ru</code> file in the application root containing the following:</p>\n    <pre class="breakout">require "config/environment"\nrequire "logger"\n\nuse Rails::Rack::LogTailer\nuse Rails::Rack::Static\nuse Rack::ShowExceptions\n\nrun Rack::URLMap.new \\n  "/" => ActionController::Dispatcher.new</pre>\n    <p>If you&rsquo;re using a version of Rails older than 2.3, you&rsquo;ll need to upgrade first.</p>\n  </section>\n'));
         });
       })));
     


### PR DESCRIPTION
Hi all,

I was using pow to serve a rails 2.3 app, which eventually got served by Heroku in production.

The app didn't have a config.ru file, so I created one as suggested by the "Rackup file missing" page.  Unfortunately, that rack file caused public assets to not be served by Heroku (thin).

This fix corrects the "Rackup file missing" page by providing a config.ru file that will work with Heroku out of the box.
