### PR TITLE
Followredirects 

### DIFF
--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -215,7 +215,8 @@
         method: req.method,
         url: "" + req.pow.url + req.url,
         headers: headers,
-        jar: false
+        jar: false,
+        followRedirect: false
       });
       req.pipe(proxy);
       proxy.pipe(res);

--- a/src/http_server.coffee
+++ b/src/http_server.coffee
@@ -201,6 +201,7 @@ module.exports = class HttpServer extends connect.HTTPServer
       url: "#{req.pow.url}#{req.url}"
       headers: headers
       jar: false
+      followRedirect: false
 
     req.pipe proxy
     proxy.pipe res


### PR DESCRIPTION
This is necessary so that redirects from the destination server are
returned to the client as expected rather than getting swallowed by the
proxy code. Important for things like logins to the destination app.

(you just need the last commit - i can't remember if there's a way to tell git/github that the other commits should be ignored for the pull request, don't have time to look it up now)
