### PR TITLE
Get Pow working under OS X Lion Server

### DIFF
--- a/lib/templates/installer/cx.pow.firewall.plist.js
+++ b/lib/templates/installer/cx.pow.firewall.plist.js
@@ -37,19 +37,19 @@ module.exports = function(__obj) {
   }
   (function() {
     (function() {
-    
-      __out.push('<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Label</key>\n\t<string>cx.pow.firewall</string>\n\t<key>ProgramArguments</key>\n\t<array>\n\t\t<string>sh</string>\n\t\t<string>-c</string>\n\t\t<string>ipfw add fwd 127.0.0.1,');
-    
+
+      __out.push('<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Label</key>\n\t<string>cx.pow.firewall</string>\n\t<key>ProgramArguments</key>\n\t<array>\n\t\t<string>sh</string>\n\t\t<string>-c</string>\n\t\t<string>ipfw add 1 fwd 127.0.0.1,');
+
       __out.push(__sanitize(this.httpPort));
-    
+
       __out.push(' tcp from any to me dst-port ');
-    
+
       __out.push(__sanitize(this.dstPort));
-    
-      __out.push(' in &amp;&amp; sysctl -w net.inet.ip.forwarding=1</string>\n\t</array>\n\t<key>RunAtLoad</key>\n\t<true/>\n\t<key>UserName</key>\n\t<string>root</string>\n</dict>\n</plist>\n');
-    
+
+      __out.push(' in &amp;&amp; sysctl -w net.inet.ip.forwarding=1 net.inet.ip.fw.enable=1</string>\n\t</array>\n\t<key>RunAtLoad</key>\n\t<true/>\n\t<key>UserName</key>\n\t<string>root</string>\n</dict>\n</plist>\n');
+
     }).call(this);
-    
+
   }).call(__obj);
   __obj.safe = __objSafe, __obj.escape = __escape;
   return __out.join('');


### PR DESCRIPTION
Changes suggested by @kupinus to resolve #172.
- The `ipfw` firewall rule is now created before all other rules.
- Set `net.inet.ip.fw.enable` in addition to `net.inet.ip.forwarding`.
