### PR TITLE
Don't redirect static directories

### DIFF
--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -176,7 +176,9 @@
       if (req.url.match(/\.\./)) {
         return next();
       }
-      handler = (_ref2 = (_base = this.staticHandlers)[root]) != null ? _ref2 : _base[root] = connect["static"](join(root, "public"));
+      handler = (_ref2 = (_base = this.staticHandlers)[root]) != null ? _ref2 : _base[root] = connect["static"](join(root, "public"), {
+        redirect: false
+      });
       return handler(req, res, next);
     };
 

--- a/src/http_server.coffee
+++ b/src/http_server.coffee
@@ -157,7 +157,7 @@ module.exports = class HttpServer extends connect.HTTPServer
     if req.url.match /\.\./
       return next()
 
-    handler = @staticHandlers[root] ?= connect.static join(root, "public")
+    handler = @staticHandlers[root] ?= connect.static(join(root, "public"), redirect: false)
     handler req, res, next
 
   # Check to see if the application root contains a `config.ru`


### PR DESCRIPTION
The connect static middleware is redirecting bare directory URLs to append a slash, discarding the query, and without giving the app a chance to respond. This prevents the redirection.

Say I have a collection of gems like public/gems/blah.gem, and I have a search interface at "/gems" in my app. Requesting "/gems?search=blah" is redirected by the static middleware to "/gems/" so the user gets a listing of all gems instead of the search results, etc.
