### PR TITLE
Do not ignore variables without values when parsing environments

### DIFF
--- a/src/util.coffee
+++ b/src/util.coffee
@@ -233,7 +233,7 @@ getUserLocale = (callback) ->
 parseEnv = (stdout) ->
   env = {}
   for line in stdout.split "\n"
-    if matches = line.match /([^=]+)=(.+)/
+    if matches = line.match /([^=]+)=(.*)/
       [match, name, value] = matches
       env[name] = value
   env


### PR DESCRIPTION
Fixes #379
