### PR TITLE
Change listen() in DnsServer to use socket creation callback interface.

### DIFF
--- a/src/dns_server.coffee
+++ b/src/dns_server.coffee
@@ -23,8 +23,7 @@ module.exports = class DnsServer extends dnsserver.Server
   # `DnsServer` quack like a `HttpServer` (for initialization, at
   # least).
   listen: (port, callback) ->
-    @bind port
-    callback?()
+    @bind port, -> callback?()
 
   # Each incoming DNS request ends up here. If it's an `A` query
   # and the domain name matches the top-level domain specified in our


### PR DESCRIPTION
Per reference in
[10.26 UDP docs](http://nodejs.org/api/dgram.html#dgram_udp_datagram_sockets):

> Important note: the behavior of dgram.Socket#bind() has changed in v0.10 and is always asynchronous now.

The listen interface calls bind() on the underlying dns_server/Socket, and immediately invokes its own callback if provided. This has been changed to call it from inside the callback arg in the new `bind(port, [adr], [cb])` format, which fixes test breakage in `test_dns_server.coffee` due to trying to call `address` too soon.
