### PR TITLE
Use full path to /bin/sh in cx.pow.firewall.plist ProgramArguments.

### DIFF
--- a/lib/templates/installer/cx.pow.firewall.plist.js
+++ b/lib/templates/installer/cx.pow.firewall.plist.js
@@ -37,7 +37,7 @@ module.exports = function(__obj) {
   }
   (function() {
     (function() {
-      __out.push('<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Label</key>\n\t<string>cx.pow.firewall</string>\n\t<key>ProgramArguments</key>\n\t<array>\n\t\t<string>sh</string>\n\t\t<string>-c</string>\n\t\t<string>ipfw add fwd 127.0.0.1,');
+      __out.push('<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Label</key>\n\t<string>cx.pow.firewall</string>\n\t<key>ProgramArguments</key>\n\t<array>\n\t\t<string>/bin/sh</string>\n\t\t<string>-c</string>\n\t\t<string>ipfw add fwd 127.0.0.1,');
     
       __out.push(__sanitize(this.httpPort));
     

--- a/src/templates/installer/cx.pow.firewall.plist.eco
+++ b/src/templates/installer/cx.pow.firewall.plist.eco
@@ -6,7 +6,7 @@
 	<string>cx.pow.firewall</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>sh</string>
+		<string>/bin/sh</string>
 		<string>-c</string>
 		<string>ipfw add fwd 127.0.0.1,<%= @httpPort %> tcp from any to me dst-port <%= @dstPort %> in &amp;&amp; sysctl -w net.inet.ip.forwarding=1 &amp;&amp; sysctl -w net.inet.ip.fw.enable=1</string>
 	</array>


### PR DESCRIPTION
The cx.pow.firewall.plist LaunchDaemon fails to load when "sh" is supplied as the initial ProgramArgument. Replacing with complete path, (e.g., /bin/sh).
