### PR TITLE
Removes Node 0.8 with broken semver.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.8"
 notifications:
   disabled: true


### PR DESCRIPTION
Semver is broken in Node 0.8. No need to test against that version anymore.
