### PR TITLE
Removing support for project configuration in .envrc.

### DIFF
--- a/lib/rack_application.js
+++ b/lib/rack_application.js
@@ -82,7 +82,7 @@
     RackApplication.prototype.loadScriptEnvironment = function(env, callback) {
       var _this = this;
 
-      return async.reduce([".powrc", ".envrc", ".powenv"], env, function(env, filename, callback) {
+      return async.reduce([".powrc", ".powenv"], env, function(env, filename, callback) {
         var script;
 
         return fs.exists(script = join(_this.root, filename), function(scriptExists) {

--- a/src/rack_application.coffee
+++ b/src/rack_application.coffee
@@ -93,7 +93,7 @@ module.exports = class RackApplication
   # into a source code repository for global configuration, leaving
   # `.powenv` free for any necessary local overrides.
   loadScriptEnvironment: (env, callback) ->
-    async.reduce [".powrc", ".envrc", ".powenv"], env, (env, filename, callback) =>
+    async.reduce [".powrc", ".powenv"], env, (env, filename, callback) =>
       fs.exists script = join(@root, filename), (scriptExists) ->
         if scriptExists
           sourceScriptEnv script, env, callback


### PR DESCRIPTION
Fixes #462. This file has been replaced by .powrc and .powenv, and it conflicts with direnv's use of a file with the same name.

Tests still run, and I didn't see any mention of this file in the docs.

@elia This would conflict with the changes you're making in #467. If @sstephenson doesn't mind fixing two issues in a single PR, then it would probably make sense to omit this file in your changes and close this PR. Otherwise, this would need to be merged first.