### PR TITLE
Fix reinstall/upgrade on OS X Yosemite

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -160,8 +160,7 @@
         sudo "$NODE_BIN" "$POW_BIN" --install-system
 
         if [ "$MAC_OS_MINOR_VERSION" -ge 10 ]; then
-          sudo launchctl bootstrap system /Library/LaunchDaemons/cx.pow.firewall.plist 2>/dev/null
-          sudo launchctl enable system/cx.pow.firewall 2>/dev/null
+          sudo launchctl load -Fw /Library/LaunchDaemons/cx.pow.firewall.plist 2>/dev/null
           sudo launchctl kickstart -k system/cx.pow.firewall 2>/dev/null
         else
           sudo launchctl load -Fw /Library/LaunchDaemons/cx.pow.firewall.plist 2>/dev/null
@@ -174,8 +173,7 @@
       echo "*** Starting the Pow server..."
 
       if [ "$MAC_OS_MINOR_VERSION" -ge 10 ]; then
-        launchctl bootstrap gui/"$UID" "$HOME/Library/LaunchAgents/cx.pow.powd.plist" 2>/dev/null
-        launchctl enable gui/"$UID"/cx.pow.powd 2>/dev/null
+        launchctl load -Fw "$HOME/Library/LaunchAgents/cx.pow.powd.plist" 2>/dev/null
         launchctl kickstart -k gui/"$UID"/cx.pow.powd 2>/dev/null
       else
         launchctl unload "$HOME/Library/LaunchAgents/cx.pow.powd.plist" 2>/dev/null || true


### PR DESCRIPTION
Fixes #473

When running the install script multiple times on Yosemite (10.10), the
`launchctl bootstrap` commands fail with a 133 exit code and a message
“Operation already in progress”.

I’ve found that the `bootstrap`/`enable` commands can be replaced with
`load -Fw` to ensure the job is running.

`kickstart -k` is still needed to restart the job in the case of an
upgrade or re-installation.

NB: I'm not very familiar w/ launchctl and I couldn't find much documentation beyond the `man` page.

I'm also not sure why or if the `-F` force flag is needed for `load`, but I saw it used elsewhere, and it doesn't seem to hurt.

This is tested on the latest public version of OS X Yosemite, `10.10.3`.