### PR TITLE
Add a tiny bit of extra protection for users when uninstalling.

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -68,7 +68,10 @@
 
 # Remove the Versions directory and the Current symlink.
 
-      rm -fr "$POW_VERSIONS_PATH"
+      if [ "$POW_VERSIONS_PATH" != "/" ] && [ "$POW_VERSIONS_PATH" != "/*" ]; then
+        rm -fr "$POW_VERSIONS_PATH"
+      else echo "Uninstall aborted because POW_VERSIONS_PATH was set wrong"
+      fi
       rm -f "$POW_CURRENT_PATH"
 
 


### PR DESCRIPTION
I appreciate the ["review this script"](https://github.com/basecamp/pow/blame/163f546854b833bd8bb097cf9bad5be8420da727/MANUAL.md#L40) call out in the uninstall procedures. I feel in general that it's bad to be habituating users to `curl` / `wget` | `sh` style installation procedures, but I'm not aware of a better solution either. In lieu of a better solution, this is my own tiny contribution to script safety for this specific script.