### PR TITLE
Made it possible to configure the IP that will be resolved

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -50,7 +50,7 @@
       });
     };
 
-    Configuration.optionNames = ["bin", "dstPort", "httpPort", "dnsPort", "timeout", "workers", "domains", "extDomains", "hostRoot", "logRoot", "rvmPath"];
+    Configuration.optionNames = ["bin", "dstPort", "httpPort", "dnsPort", "timeout", "workers", "domains", "extDomains", "hostRoot", "logRoot", "rvmPath", "ip"];
 
     function Configuration(env) {
       if (env == null) {
@@ -61,7 +61,7 @@
     }
 
     Configuration.prototype.initialize = function(env) {
-      var _base, _base1, _ref, _ref1, _ref10, _ref11, _ref12, _ref13, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
+      var _base, _base1, _ref, _ref1, _ref10, _ref11, _ref12, _ref13, _ref14, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
 
       this.env = env;
       this.bin = (_ref = env.POW_BIN) != null ? _ref : path.join(__dirname, "../bin/pow");
@@ -80,6 +80,7 @@
       this.hostRoot = (_ref11 = env.POW_HOST_ROOT) != null ? _ref11 : path.join(this.supportRoot, "Hosts");
       this.logRoot = (_ref12 = env.POW_LOG_ROOT) != null ? _ref12 : libraryPath("Logs", "Pow");
       this.rvmPath = (_ref13 = env.POW_RVM_PATH) != null ? _ref13 : path.join(process.env.HOME, ".rvm/scripts/rvm");
+      this.ip = (_ref14 = env.POW_IP) != null ? _ref14 : "127.0.0.1";
       this.dnsDomainPattern = compilePattern(this.domains);
       return this.httpDomainPattern = compilePattern(this.allDomains);
     };

--- a/lib/dns_server.js
+++ b/lib/dns_server.js
@@ -34,7 +34,7 @@
       pattern = this.configuration.dnsDomainPattern;
       q = (_ref = req.question) != null ? _ref : {};
       if (q.type === NS_T_A && q["class"] === NS_C_IN && pattern.test(q.name)) {
-        res.addRR(q.name, NS_T_A, NS_C_IN, 600, "127.0.0.1");
+        res.addRR(q.name, NS_T_A, NS_C_IN, 600, this.configuration.ip);
       } else {
         res.header.rcode = NS_RCODE_NXDOMAIN;
       }

--- a/src/configuration.coffee
+++ b/src/configuration.coffee
@@ -52,7 +52,7 @@ module.exports = class Configuration
   # A list of option names accessible on `Configuration` instances.
   @optionNames: [
     "bin", "dstPort", "httpPort", "dnsPort", "timeout", "workers",
-    "domains", "extDomains", "hostRoot", "logRoot", "rvmPath"
+    "domains", "extDomains", "hostRoot", "logRoot", "rvmPath", "ip"
   ]
 
   # Pass in any environment variables you'd like to override when
@@ -123,6 +123,9 @@ module.exports = class Configuration
     # `POW_RVM_PATH` (**deprecated**): path to the rvm initialization
     # script. Defaults to `~/.rvm/scripts/rvm`.
     @rvmPath    = env.POW_RVM_PATH    ? path.join process.env.HOME, ".rvm/scripts/rvm"
+
+    # `POW_IP`: the ip that should be resolved. Defaults to 127.0.0.1
+    @ip         = env.POW_IP          ? "127.0.0.1"
 
     # ---
     # Precompile regular expressions for matching domain names to be

--- a/src/dns_server.coffee
+++ b/src/dns_server.coffee
@@ -36,7 +36,7 @@ module.exports = class DnsServer extends dnsserver.Server
     q = req.question ? {}
 
     if q.type is NS_T_A and q.class is NS_C_IN and pattern.test q.name
-      res.addRR q.name, NS_T_A, NS_C_IN, 600, "127.0.0.1"
+      res.addRR q.name, NS_T_A, NS_C_IN, 600, @configuration.ip
     else
       res.header.rcode = NS_RCODE_NXDOMAIN
 


### PR DESCRIPTION
This introduces a new variable `POW_IP` that can be configured thru
`~/.powconfig`. It defaults to 127.0.0.1

This can be useful if you are using a vagrant-box with a fixed ip that is used for development.
