### PR TITLE
Switch from `.dev` to `.test`

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -14,18 +14,18 @@ tedious configuration. Pow runs as your user on an unprivileged port,
 and includes both an HTTP and a DNS server. The installation process
 sets up a firewall rule to forward incoming requests on port 80 to
 Pow. It also sets up a system hook so that all DNS queries for a
-special top-level domain (`.dev`) resolve to your local machine.
+special top-level domain (`.test`) resolve to your local machine.
 
 To serve a Rack app, just symlink it into your `~/.pow`
 directory. Let's say you're working on an app that lives in
 `~/Projects/myapp`. You'd like to access it at
-`http://myapp.dev/`. Setting it up is as easy as:
+`http://myapp.test/`. Setting it up is as easy as:
 
     $ cd ~/.pow
     $ ln -s ~/Projects/myapp
 
 That's it! The name of the symlink (`myapp`) determines the hostname
-you use (`myapp.dev`) to access the application it points to
+you use (`myapp.test`) to access the application it points to
 (`~/Projects/myapp`).
 
 -----
@@ -90,13 +90,13 @@ time it's accessed, and will keep up to two workers running for each
 application. Workers are automatically terminated after 15 minutes of
 inactivity.
 
-### Using Virtual Hosts and the .dev Domain ###
+### Using Virtual Hosts and the .test Domain ###
 
 A _virtual host_ specifies a mapping between a hostname and an
 application. To install a virtual host, symlink a Rack application
 into your `~/.pow` directory. The name of the symlink tells Pow which
 hostname you want to use to access the application. For example, a
-symlink named `myapp` will be accessible at `http://myapp.dev/`.
+symlink named `myapp` will be accessible at `http://myapp.test/`.
 
 **Note**: The Pow installer creates `~/.pow` as a convenient symlink
   to `~/Library/Application Support/Pow/Hosts`, the actual location
@@ -107,8 +107,8 @@ symlink named `myapp` will be accessible at `http://myapp.dev/`.
 Once a virtual host is installed, it's also automatically accessible
 from all subdomains of the named host. For example, the `myapp`
 virtual host described above could also be accessed at
-`http://www.myapp.dev/` and `http://assets.www.myapp.dev/`. You can
-override this behavior to, say, point `www.myapp.dev` to a different
+`http://www.myapp.test/` and `http://assets.www.myapp.test/`. You can
+override this behavior to, say, point `www.myapp.test` to a different
 application &mdash; just create another virtual host symlink named
 `www.myapp` for the application you want.
 
@@ -138,12 +138,12 @@ particular hostname to another port or IP address. To use it, just
 create a file in `~/.pow` (instead of a symlink) with the destination
 port number as its contents.
 
-For example, to forward all traffic for `http://proxiedapp.dev/` to
+For example, to forward all traffic for `http://proxiedapp.test/` to
 port 8080 on your localhost:
 
     $ echo 8080 > ~/.pow/proxiedapp
 
-To forward traffic for `http://proxiedapp.dev/` to an IP address other
+To forward traffic for `http://proxiedapp.test/` to an IP address other
 than localhost (such as a virtual machine), create a file with the destination
 protocol, IP, and port:
 
@@ -159,14 +159,14 @@ Sometimes you need to access your Pow virtual hosts from another
 computer on your local network &mdash; for example, when testing your
 application on a mobile device or from a Windows or Linux VM.
 
-The `.dev` domain will only work on your development
+The `.test` domain will only work on your development
 computer. However, you can use the special [`.xip.io`
 domain](http://xip.io/) to remotely access your Pow virtual hosts.
 
 Construct your xip.io domain by appending your application's name to
 your LAN IP address followed by `.xip.io`. For example, if your
 development computer's LAN IP address is `10.0.1.43`, you can visit
-`myapp.dev` from another computer on your local network using the URL
+`myapp.test` from another computer on your local network using the URL
 `http://myapp.10.0.1.43.xip.io/`.
 
 ### Customizing Environment Variables ###
@@ -346,13 +346,18 @@ full list of settings that you can change.
 
 The `POW_DOMAINS` environment variable specifies a comma-separated
 list of top-level domains for which Pow will serve DNS queries and
-HTTP requests. The default value for this list is a single domain,
-`dev`, meaning Pow will configure your system to resolve `*.dev` to
-127.0.0.1 and serve apps in `~/.pow` under the `.dev` domain.
+HTTP requests. The default value for this list are the two `test,dev`
+domains, meaning Pow will configure your system to resolve `*.test`
+and `*.dev` to 127.0.0.1 and serve apps in `~/.pow` under the
+`.test` and `.dev` domains.
+
+The `.test` domain is preferred since Google owns the `.dev` TLD and
+has recently enabled HSTS, forcing all requests to use HTTPS. Pow
+supports `.dev` by default for backward compatibility only.
 
 You can add additional domains to `POW_DOMAINS`:
 
-    export POW_DOMAINS=dev,test
+    export POW_DOMAINS=test,local
 
 If you want Pow to serve apps under additional top-level domains, but
 not serve DNS queries for those domains, use the `POW_EXT_DOMAINS`
@@ -436,7 +441,7 @@ Process button.
   over the web." It creates a tunnel between your computer and the
   Forward server, then gives you a publicly accessible URL so others
   can see the app or site you're working on. Install the gem via (`gem install forward`) and
-  then run `forward yourapp.dev`. Your Pow application will be
+  then run `forward yourapp.test`. Your Pow application will be
   accessible at `https://youraccount.fwd.wf/`.
 
 ## Contributing ##

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To set up a Rack app, just symlink it into `~/.pow`:
     $ cd ~/.pow
     $ ln -s /path/to/myapp
 
-That's it! Your app will be up and running at `http://myapp.dev/`.
+That's it! Your app will be up and running at `http://myapp.test/`.
 See the [user's manual](http://pow.cx/manual) for more information.
 
 -----

--- a/src/configuration.coffee
+++ b/src/configuration.coffee
@@ -16,7 +16,7 @@ module.exports = class Configuration
   # boot.  You can configure options such as the top-level domain,
   # number of workers, the worker idle timeout, and listening ports.
   #
-  #     export POW_DOMAINS=dev,test
+  #     export POW_DOMAINS=test,local
   #     export POW_WORKERS=3
   #
   # See the `Configuration` constructor for a complete list of
@@ -89,18 +89,18 @@ module.exports = class Configuration
     @workers    = env.POW_WORKERS     ? 2
 
     # `POW_DOMAINS`: the top-level domains for which Pow will respond
-    # to DNS `A` queries with `127.0.0.1`. Defaults to `dev`. If you
-    # configure this in your `~/.powconfig` you will need to re-run
-    # `sudo pow --install-system` to make `/etc/resolver` aware of
-    # the new TLDs.
-    @domains    = env.POW_DOMAINS     ? env.POW_DOMAIN ? "dev"
+    # to DNS `A` queries with `127.0.0.1`. Defaults to `test,dev`.
+    # If you configure this in your `~/.powconfig` you will need to
+    # re-run `sudo pow --install-system` to make `/etc/resolver` aware
+    # of the new TLDs.
+    @domains    = env.POW_DOMAINS     ? env.POW_DOMAIN ? "test,dev"
 
     # `POW_EXT_DOMAINS`: additional top-level domains for which Pow
     # will serve HTTP requests (but not DNS requests -- hence the
     # "ext").
     @extDomains = env.POW_EXT_DOMAINS ? []
 
-    # Allow for comma-separated domain lists, e.g. `POW_DOMAINS=dev,test`
+    # Allow for comma-separated domain lists, e.g. `POW_DOMAINS=test,dev`
     @domains    = @domains.split?(",")    ? @domains
     @extDomains = @extDomains.split?(",") ? @extDomains
     @allDomains = @domains.concat @extDomains
@@ -223,8 +223,8 @@ libraryPath = (args...) ->
 # Strip a trailing `domain` from the given `host`, then generate a
 # sorted array of possible entry names for finding which application
 # should serve the host. For example, a `host` of
-# `asset0.37s.basecamp.dev` will produce `["asset0.37s.basecamp",
-# "37s.basecamp", "basecamp"]`, and `basecamp.dev` will produce
+# `asset0.37s.basecamp.test` will produce `["asset0.37s.basecamp",
+# "37s.basecamp", "basecamp"]`, and `basecamp.test` will produce
 # `["basecamp"]`.
 getFilenamesForHost = (host, domain) ->
   host = host.toLowerCase()


### PR DESCRIPTION
In light of Google enabling HSTS on the `.dev` TLD. Maintains support for `.dev` for backward compatibility.

The `.test` TLD is reserved (along with `.example`, `.invalid`, and `.localhost`) per RFC 2606 and RFC 6761: https://tools.ietf.org/html/rfc6761#section-6.2

```   
    6.2.  Domain Name Reservation Considerations for "test."
    
    The domain "test.", and any names falling within ".test.", are
    special in the following ways:
    
    1.  Users are free to use these test names as they would any other
    domain names.  However, since there is no central authority
    responsible for use of test names, users SHOULD be aware that
    these names are likely to yield different results on different
    networks.
    
    2.  Application software SHOULD NOT recognize test names as special,
    and SHOULD use test names as they would other domain names.
    
    3.  Name resolution APIs and libraries SHOULD NOT recognize test
    names as special and SHOULD NOT treat them differently.  Name
    resolution APIs SHOULD send queries for test names to their
    configured caching DNS server(s).
```