### PR TITLE
Release 0.6.0 with .test TLD support. Last foreseeable release.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -468,6 +468,13 @@ looks like.
 
 ## Version History ##
 
+* **0.6.0** (December 5, 2017):
+  * Switch top-level domain from .dev to .test. Google owns .dev and
+    enabled HSTS on it, breaking non-HTTPS sites. The .dev TLD is still
+    enabled for backward compatibility, but .test is the new default.
+  * This is the last release for the forseeable future. Check out
+    [puma-dev](https://github.com/puma/puma-dev#readme) for a contemporary alternative.
+
 * **0.5.0** (October 16, 2014):
   * Support for OS X Yosemite. Pow no longer uses the ipfw firewall,
     which was deprecated in OS X 10.9 and removed in 10.10. Port

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 -----
 
-Current Version: **0.5.0**
+Current Version: **0.6.0**
 
 To install or upgrade Pow, open a terminal and run this command:
 

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@
       POW_ROOT="$HOME/Library/Application Support/Pow"
       NODE_BIN="$POW_ROOT/Current/bin/node"
       POW_BIN="$POW_ROOT/Current/bin/pow"
-      LATEST_VERSION="0.5.0"
+      LATEST_VERSION="0.6.0"
 
       if [ -z "$ARCHIVE_URL_ROOT" ]; then
         ARCHIVE_URL_ROOT="http://get.pow.cx/versions"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 { "name": "pow"
 , "description": "Zero-configuration Rack server for Mac OS X"
-, "version": "0.5.0"
+, "version": "0.6.0"
 , "author": "Sam Stephenson"
 , "repository":
   { "type": "git"
-  , "url": "http://github.com/sstephenson/pow.git"
+  , "url": "https://github.com/sstephenson/pow.git"
   }
 , "bin": { "pow": "./bin/pow" }
 , "main": "./lib/index.js"


### PR DESCRIPTION
Release #547 and put a bow on it.