### PR TITLE
show 'test' as default subdomain in welcome hint

### DIFF
--- a/src/http_server.coffee
+++ b/src/http_server.coffee
@@ -278,7 +278,7 @@ module.exports = class HttpServer extends connect.HTTPServer
   handleWelcomeRequest: (req, res, next) =>
     return next() if req.pow.root or req.url isnt "/"
     {domains} = @configuration
-    domain = if "dev" in domains then "dev" else domains[0]
+    domain = if "test" in domains then "test" else domains[0]
     renderResponse res, 200, "welcome", {version, domain}
 
   # If the request is for an app that looks like a Rails 2 app but


### PR DESCRIPTION
Since [this](http://pow.cx/manual.html#section_3.1) is the case:

>The .test domain is preferred since Google owns the .dev TLD and has recently enabled HSTS, forcing all requests to use HTTPS. Pow supports .dev by default for backward compatibility only.

`.test` domain should be shown as default one on Welcome page and `.dev` left for backward compatibility only.
  